### PR TITLE
Fix gzip decompression

### DIFF
--- a/src/LeagueToolkit/Core/Wad/WadFile.cs
+++ b/src/LeagueToolkit/Core/Wad/WadFile.cs
@@ -168,10 +168,17 @@ public sealed class WadFile : IDisposable
         using Stream decompressionStream = OpenChunk(chunk);
         MemoryOwner<byte> decompressedChunk = MemoryOwner<byte>.Allocate(chunk.UncompressedSize);
 
-        int decompressedBytes = decompressionStream.Read(decompressedChunk.Span);
-        if (decompressedBytes != chunk.UncompressedSize)
+        int totalDecompressedBytes = 0;
+        while (true)
+        {
+            int decompressedBytes = decompressionStream.Read(decompressedChunk.Span[totalDecompressedBytes..]);
+            if (decompressedBytes == 0) break;
+            totalDecompressedBytes += decompressedBytes;
+        }
+
+        if (totalDecompressedBytes != chunk.UncompressedSize)
             ThrowHelper.ThrowInvalidDataException(
-                $"Failed to decompress chunk data. decompressed: {decompressedBytes}; actual: {chunk.UncompressedSize}"
+                $"Failed to decompress chunk data. decompressed: {totalDecompressedBytes}; actual: {chunk.UncompressedSize}"
             );
 
         return decompressedChunk;

--- a/src/LeagueToolkit/Core/Wad/WadFile.cs
+++ b/src/LeagueToolkit/Core/Wad/WadFile.cs
@@ -1,6 +1,7 @@
 ﻿using CommunityToolkit.Diagnostics;
 using CommunityToolkit.HighPerformance;
 using CommunityToolkit.HighPerformance.Buffers;
+using LeagueToolkit.Utils.Extensions;
 using System.IO.Compression;
 using System.Text;
 using XXHash3NET;
@@ -168,18 +169,7 @@ public sealed class WadFile : IDisposable
         using Stream decompressionStream = OpenChunk(chunk);
         MemoryOwner<byte> decompressedChunk = MemoryOwner<byte>.Allocate(chunk.UncompressedSize);
 
-        int totalDecompressedBytes = 0;
-        while (true)
-        {
-            int decompressedBytes = decompressionStream.Read(decompressedChunk.Span[totalDecompressedBytes..]);
-            if (decompressedBytes == 0) break;
-            totalDecompressedBytes += decompressedBytes;
-        }
-
-        if (totalDecompressedBytes != chunk.UncompressedSize)
-            ThrowHelper.ThrowInvalidDataException(
-                $"Failed to decompress chunk data. decompressed: {totalDecompressedBytes}; actual: {chunk.UncompressedSize}"
-            );
+        decompressionStream.ReadExactly(decompressedChunk.Span);
 
         return decompressedChunk;
     }

--- a/src/LeagueToolkit/Core/Wad/WadFile.cs
+++ b/src/LeagueToolkit/Core/Wad/WadFile.cs
@@ -169,7 +169,7 @@ public sealed class WadFile : IDisposable
         using Stream decompressionStream = OpenChunk(chunk);
         MemoryOwner<byte> decompressedChunk = MemoryOwner<byte>.Allocate(chunk.UncompressedSize);
 
-        decompressionStream.ReadExactly(decompressedChunk.Span);
+        decompressionStream.ReadExact(decompressedChunk.Span);
 
         return decompressedChunk;
     }

--- a/src/LeagueToolkit/Utils/Extensions/StreamExtensions.cs
+++ b/src/LeagueToolkit/Utils/Extensions/StreamExtensions.cs
@@ -2,7 +2,7 @@
 {
     public static class StreamExtensions
     {
-        public static void ReadExactly(this Stream stream, Span<byte> buffer)
+        public static void ReadExact(this Stream stream, Span<byte> buffer)
         {
             int totalBytesRead = 0;
             int bytesRead;

--- a/src/LeagueToolkit/Utils/Extensions/StreamExtensions.cs
+++ b/src/LeagueToolkit/Utils/Extensions/StreamExtensions.cs
@@ -1,0 +1,19 @@
+﻿namespace LeagueToolkit.Utils.Extensions
+{
+    public static class StreamExtensions
+    {
+        public static void ReadExactly(this Stream stream, Span<byte> buffer)
+        {
+            int totalBytesRead = 0;
+            int bytesRead;
+            do
+            {
+                bytesRead = stream.Read(buffer[totalBytesRead..]);
+                totalBytesRead += bytesRead;
+            } while (bytesRead is not 0);
+
+            if (totalBytesRead != buffer.Length)
+                throw new IOException($"Failed to read {buffer.Length} bytes, bytesRead: {totalBytesRead}");
+        }
+    }
+}


### PR DESCRIPTION
`Stream.Read` may read less than the requested number of bytes, which actually does happen in the case of `GZipStream`.

The correct way to handle this is to either copy the stream entirely or use `Read` in a loop until the function returns `0`.