### PR TITLE
Enable some additional analyzers and fix code

### DIFF
--- a/src/LeagueToolkit/Core/Legacy/IO/FX/FXTrack.cs
+++ b/src/LeagueToolkit/Core/Legacy/IO/FX/FXTrack.cs
@@ -25,8 +25,8 @@ namespace LeagueToolkit.IO.FX
             this.Particle = Encoding.ASCII.GetString(br.ReadBytes(64));
             this.Bone = Encoding.ASCII.GetString(br.ReadBytes(64));
 
-            this.Particle = this.Particle.Remove(this.Particle.IndexOf(this.Particle.Contains("\0") ? '\u0000' : '?'));
-            this.Bone = this.Bone.Remove(this.Bone.IndexOf(this.Bone.Contains("\0") ? '\u0000' : '?'));
+            this.Particle = this.Particle.Remove(this.Particle.IndexOf(this.Particle.Contains('\0') ? '\u0000' : '?'));
+            this.Bone = this.Bone.Remove(this.Bone.IndexOf(this.Bone.Contains('\0') ? '\u0000' : '?'));
 
             this.SpawnOffset = br.ReadVector3();
             this.StreakInfo = new FXWeaponStreakInfo(br);

--- a/src/LeagueToolkit/Core/Legacy/IO/FX/FXWeaponStreakInfo.cs
+++ b/src/LeagueToolkit/Core/Legacy/IO/FX/FXWeaponStreakInfo.cs
@@ -30,7 +30,7 @@ namespace LeagueToolkit.IO.FX
             this.TextureMapMode = br.ReadInt32();
 
             this.Texture = Encoding.ASCII.GetString(br.ReadBytes(64));
-            this.Texture = this.Texture.Remove(this.Texture.IndexOf(this.Texture.Contains("\0") ? '\u0000' : '?'));
+            this.Texture = this.Texture.Remove(this.Texture.IndexOf(this.Texture.Contains('\0') ? '\u0000' : '?'));
 
             this.ColorOverTime = new TimeGradient(br);
             this.WidthOverTime = new TimeGradient(br);

--- a/src/LeagueToolkit/Core/Legacy/IO/MapParticles/MapParticlesParticle.cs
+++ b/src/LeagueToolkit/Core/Legacy/IO/MapParticles/MapParticlesParticle.cs
@@ -83,7 +83,7 @@ namespace LeagueToolkit.IO.MapParticles
         /// <param name="sw">The <see cref="StreamWriter"/> to write to</param>
         public void Write(StreamWriter sw)
         {
-            string write = string.Format("{0} {1} {2} {3} {4} {5} {6} {7}",
+            string write = string.Format(NumberFormatInfo.InvariantInfo, "{0} {1} {2} {3} {4} {5} {6} {7}",
                 this.Name,
                 this.Position.X,
                 this.Position.Y,

--- a/src/LeagueToolkit/Core/Legacy/IO/OBJ/OBJFile.cs
+++ b/src/LeagueToolkit/Core/Legacy/IO/OBJ/OBJFile.cs
@@ -16,7 +16,7 @@ namespace LeagueToolkit.IO.OBJ
         public List<Vector3> Normals { get; set; } = new List<Vector3>();
         public List<OBJGroup> Groups { get; set; } = new List<OBJGroup>();
         public string MaterialsFile { get; set; } = "";
-        public bool IsSmooth { get; set; } = false;
+        public bool IsSmooth { get; set; }
 
         // TODO: Refactor this garbage API
         public OBJFile(List<Vector3> vertices, List<uint> indices)
@@ -192,7 +192,7 @@ namespace LeagueToolkit.IO.OBJ
                     string format = string.Format(NumberFormatInfo.InvariantInfo, "vt {0} {1}", uv.X, 1 - uv.Y);
 
                     // Fixes issues with programs which cannot read the infinity symbol.
-                    if (format.Contains("∞"))
+                    if (format.Contains('∞'))
                     {
                         format = "vt -Infinity NaN";
                     }

--- a/src/LeagueToolkit/Core/Legacy/IO/ObjectConfig/ObjectConfigObject.cs
+++ b/src/LeagueToolkit/Core/Legacy/IO/ObjectConfig/ObjectConfigObject.cs
@@ -135,7 +135,7 @@ public class ObjectConfigObject
         this.VOSkinName = voSkinName;
         this.SwapModelOnDeathTime = swapModelOnDeathTime;
         this.DestroyedTowerSkin = destroyedTowerSkin;
-        this.DestroyedTowerSkinID = DestroyedTowerSkinID;
+        this.DestroyedTowerSkinID = destroyedTowerSkinID;
         this.WarningDecalOffset = warningDecalOffset;
         this.WarningDecalSizeFactor = warningDecalSizeFactor;
 

--- a/src/LeagueToolkit/Core/Mesh/StaticMeshFace.cs
+++ b/src/LeagueToolkit/Core/Mesh/StaticMeshFace.cs
@@ -115,14 +115,14 @@ public readonly struct StaticMeshFace
 
     internal void WriteAscii(StreamWriter sw)
     {
-        string uvs = string.Format(
+        string uvs = string.Format(NumberFormatInfo.InvariantInfo,
             "{0} {1} {2} {3} {4} {5}",
-            this.UV0.X.ToString(CultureInfo.InvariantCulture),
-            this.UV1.X.ToString(CultureInfo.InvariantCulture),
-            this.UV2.X.ToString(CultureInfo.InvariantCulture),
-            this.UV0.Y.ToString(CultureInfo.InvariantCulture),
-            this.UV1.Y.ToString(CultureInfo.InvariantCulture),
-            this.UV2.Y.ToString(CultureInfo.InvariantCulture)
+            this.UV0.X,
+            this.UV1.X,
+            this.UV2.X,
+            this.UV0.Y,
+            this.UV1.Y,
+            this.UV2.Y
         );
 
         sw.WriteLine(

--- a/src/LeagueToolkit/Core/Primitives/Color.cs
+++ b/src/LeagueToolkit/Core/Primitives/Color.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.InteropServices;
 
 namespace LeagueToolkit.Core.Primitives;
@@ -15,7 +16,7 @@ public struct Color : IEquatable<Color>
         set
         {
             if (value < 0 || value > 1)
-                throw new ArgumentOutOfRangeException("value", "value must be in 0-1 range");
+                throw new ArgumentOutOfRangeException(nameof(value), "value must be in 0-1 range");
             else
                 this._r = value;
         }
@@ -26,7 +27,7 @@ public struct Color : IEquatable<Color>
         set
         {
             if (value < 0 || value > 1)
-                throw new ArgumentOutOfRangeException("value", "value must be in 0-1 range");
+                throw new ArgumentOutOfRangeException(nameof(value), "value must be in 0-1 range");
             else
                 this._g = value;
         }
@@ -37,7 +38,7 @@ public struct Color : IEquatable<Color>
         set
         {
             if (value < 0 || value > 1)
-                throw new ArgumentOutOfRangeException("value", "value must be in 0-1 range");
+                throw new ArgumentOutOfRangeException(nameof(value), "value must be in 0-1 range");
             else
                 this._b = value;
         }
@@ -48,7 +49,7 @@ public struct Color : IEquatable<Color>
         set
         {
             if (value < 0 || value > 1)
-                throw new ArgumentOutOfRangeException("value", "value must be in 0-1 range");
+                throw new ArgumentOutOfRangeException(nameof(value), "value must be in 0-1 range");
             else
                 this._a = value;
         }
@@ -177,7 +178,7 @@ public struct Color : IEquatable<Color>
         }
         else
         {
-            throw new ArgumentException(nameof(format), $"Unsupported color format: {format}");
+            throw new ArgumentException($"Unsupported color format: {format}", nameof(format));
         }
     }
 
@@ -275,19 +276,19 @@ public struct Color : IEquatable<Color>
         }
         else if (format == ColorFormat.RgbF32)
         {
-            return string.Format("{0} {1} {2}", this.R, this.G, this.B);
+            return string.Format(NumberFormatInfo.InvariantInfo, "{0} {1} {2}", this.R, this.G, this.B);
         }
         else if (format == ColorFormat.RgbaF32)
         {
-            return string.Format("{0} {1} {2} {3}", this.R, this.G, this.B, this.A);
+            return string.Format(NumberFormatInfo.InvariantInfo, "{0} {1} {2} {3}", this.R, this.G, this.B, this.A);
         }
         else if (format == ColorFormat.BgrF32)
         {
-            return string.Format("{0} {1} {2}", this.B, this.G, this.R);
+            return string.Format(NumberFormatInfo.InvariantInfo, "{0} {1} {2}", this.B, this.G, this.R);
         }
         else if (format == ColorFormat.BgraF32)
         {
-            return string.Format("{0} {1} {2} {3}", this.B, this.G, this.R, this.A);
+            return string.Format(NumberFormatInfo.InvariantInfo, "{0} {1} {2} {3}", this.B, this.G, this.R, this.A);
         }
         else
         {

--- a/src/LeagueToolkit/Core/Wad/WadBuilder.cs
+++ b/src/LeagueToolkit/Core/Wad/WadBuilder.cs
@@ -50,7 +50,7 @@ public static class WadBuilder
 
         // Seek to start and write actual descriptor
         bakedWadStream.Seek(0, SeekOrigin.Begin);
-        WadFile bakedWad = new(context.Chunks);
+        using WadFile bakedWad = new(context.Chunks);
         bakedWad.WriteDescriptor(bakedWadStream);
     }
 
@@ -82,7 +82,7 @@ public static class WadBuilder
         // Create chunk
         string chunkPath = Path.GetRelativePath(context.RootDirectory, filePath)
             .Replace(Path.DirectorySeparatorChar, '/')
-            .ToLower();
+            .ToLowerInvariant();
 
         WadChunk chunk =
             new(

--- a/src/LeagueToolkit/Core/Wad/WadFile.cs
+++ b/src/LeagueToolkit/Core/Wad/WadFile.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.HighPerformance;
 using CommunityToolkit.HighPerformance.Buffers;
 using LeagueToolkit.Utils.Extensions;
 using System;
+using System.Globalization;
 using System.IO.Compression;
 using System.Text;
 using XXHash3NET;
@@ -103,8 +104,8 @@ public sealed class WadFile : IDisposable
         // Read subchunk table
         // May this substring not crash till the end of times, amen :^)
         string subchunkTocPath = Path.ChangeExtension(
-            stream.Name[(stream.Name.LastIndexOf(GAME_DIRECTORY_NAME) + GAME_DIRECTORY_NAME.Length + 1)..]
-                .ToLower()
+            stream.Name[(stream.Name.LastIndexOf(GAME_DIRECTORY_NAME, StringComparison.Ordinal) + GAME_DIRECTORY_NAME.Length + 1)..]
+                .ToLowerInvariant()
                 .Replace(Path.DirectorySeparatorChar, '/'),
             "subchunktoc"
         );
@@ -236,7 +237,7 @@ public sealed class WadFile : IDisposable
     {
         Guard.IsNotNullOrEmpty(path, nameof(path));
 
-        return FindChunk(XXHash64.Compute(path.ToLower()));
+        return FindChunk(XXHash64.Compute(path.ToLowerInvariant()));
     }
 
     /// <summary>

--- a/src/LeagueToolkit/Hashing/Elf.cs
+++ b/src/LeagueToolkit/Hashing/Elf.cs
@@ -27,6 +27,6 @@
             return hash;
         }
 
-        public static uint HashLower(string value) => Hash(value.ToLower());
+        public static uint HashLower(string value) => Hash(value.ToLowerInvariant());
     }
 }

--- a/src/LeagueToolkit/Hashing/Fnv1a.cs
+++ b/src/LeagueToolkit/Hashing/Fnv1a.cs
@@ -4,7 +4,7 @@
     {
         public static uint HashLower(string input)
         {
-            input = input.ToLower();
+            input = input.ToLowerInvariant();
 
             uint hash = 2166136261;
             for (int i = 0; i < input.Length; i++)

--- a/src/LeagueToolkit/Hashing/Sdbm.cs
+++ b/src/LeagueToolkit/Hashing/Sdbm.cs
@@ -49,11 +49,11 @@ namespace LeagueToolkit.Hashing
             return hash;
         }
 
-        public static uint HashLower(string value) => Hash(value.ToLower());
+        public static uint HashLower(string value) => Hash(value.ToLowerInvariant());
 
-        public static uint HashLower(string key, string value) => Hash(key.ToLower(), value.ToLower());
+        public static uint HashLower(string key, string value) => Hash(key.ToLowerInvariant(), value.ToLowerInvariant());
 
         public static uint HashLowerWithDelimiter(string key, string value, char delimiter) =>
-            HashWithDelimiter(key.ToLower(), value.ToLower(), delimiter);
+            HashWithDelimiter(key.ToLowerInvariant(), value.ToLowerInvariant(), delimiter);
     }
 }

--- a/src/LeagueToolkit/LeagueToolkit.csproj
+++ b/src/LeagueToolkit/LeagueToolkit.csproj
@@ -5,6 +5,12 @@
   <PropertyGroup>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <ImplicitUsings>enable</ImplicitUsings>
+    <AnalysisModeGlobalization>Recommended</AnalysisModeGlobalization>
+    <AnalysisModeMaintainability>All</AnalysisModeMaintainability>
+    <AnalysisModePerformance>Recommended</AnalysisModePerformance>
+    <AnalysisModeReliability>All</AnalysisModeReliability>
+    <AnalysisModeUsage>Recommended</AnalysisModeUsage>
+    <NoWarn>$(NoWarn);CA1305</NoWarn>
   </PropertyGroup>
 
   <!-- information about the assembly/project/package -->

--- a/src/LeagueToolkit/Toolkit/Ritobin/RitobinWriter.cs
+++ b/src/LeagueToolkit/Toolkit/Ritobin/RitobinWriter.cs
@@ -107,7 +107,7 @@ public sealed class RitobinWriter : IDisposable
     private void WritePropertyValue(BinTreeProperty property)
     {
         if (property is BinTreeBool boolProperty)
-            this._writer.Write(boolProperty.Value.ToString().ToLower());
+            this._writer.Write(boolProperty.Value.ToString().ToLowerInvariant());
         else if (property is BinTreeI8 i8)
             this._writer.Write(i8);
         else if (property is BinTreeU8 u8)
@@ -157,7 +157,7 @@ public sealed class RitobinWriter : IDisposable
         else if (property is BinTreeMap map)
             WriteMapProperty(map);
         else if (property is BinTreeBitBool bitBool)
-            this._writer.Write(bitBool.Value.ToString().ToLower());
+            this._writer.Write(bitBool.Value.ToString().ToLowerInvariant());
     }
 
     private void WriteVector2Property(BinTreeVector2 property) =>


### PR DESCRIPTION
[CA1305](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1305) does catch some incorrect usages of e.g. `float.Parse()`, but it also has tons of either irrelevant or downright wrong detections, like `byte.ToString()` gets flagged even though no format provider is ever used in its implementation, so I've decided to disable it.

I have fixed some of its valid findings manually though.