### PR TITLE
Change RitobinWriter to a StringWriter

### DIFF
--- a/src/LeagueToolkit.Sandbox/Program.cs
+++ b/src/LeagueToolkit.Sandbox/Program.cs
@@ -72,17 +72,15 @@ class Program
         );
         BinTree bin = new(binFile);
 
-        FileStream ritobinStream = File.Create("ritobintest.txt");
         using RitobinWriter writer =
             new(
-                ritobinStream,
                 new Dictionary<uint, string>(),
                 new Dictionary<uint, string>(),
                 new Dictionary<uint, string>(),
                 new Dictionary<uint, string>()
             );
 
-        writer.WritePropertyBin(bin);
+        File.WriteAllText("ritobintest.txt", writer.WritePropertyBin(bin));
     }
 
     static void ProfileNvrToEnvironmentAsset()

--- a/src/LeagueToolkit/Toolkit/Ritobin/RitobinWriter.cs
+++ b/src/LeagueToolkit/Toolkit/Ritobin/RitobinWriter.cs
@@ -1,5 +1,4 @@
-﻿using CommunityToolkit.Diagnostics;
-using LeagueToolkit.Core.Meta;
+﻿using LeagueToolkit.Core.Meta;
 using LeagueToolkit.Core.Meta.Properties;
 using System.Globalization;
 
@@ -14,21 +13,18 @@ public sealed class RitobinWriter : IDisposable
     private readonly Dictionary<uint, string> _properties;
     private readonly Dictionary<uint, string> _hashes;
 
-    private readonly StreamWriter _writer;
+    private readonly StringWriter _writer;
 
     public bool IsDisposed { get; private set; }
 
     public RitobinWriter(
-        Stream stream,
         IEnumerable<KeyValuePair<uint, string>> objects,
         IEnumerable<KeyValuePair<uint, string>> classes,
         IEnumerable<KeyValuePair<uint, string>> properties,
         IEnumerable<KeyValuePair<uint, string>> hashes
     )
     {
-        Guard.IsNotNull(stream, nameof(stream));
-
-        this._writer = new StreamWriter(stream, leaveOpen: true);
+        this._writer = new StringWriter(CultureInfo.InvariantCulture);
 
         this._objects = new(objects);
         this._classes = new(classes);
@@ -36,13 +32,17 @@ public sealed class RitobinWriter : IDisposable
         this._hashes = new(hashes);
     }
 
-    public void WritePropertyBin(BinTree bin)
+    public string WritePropertyBin(BinTree bin)
     {
+        this._writer.GetStringBuilder().Clear();
+
         WriteHeader();
         WriteFileType();
         WriteVersion();
         WriteDependencies(bin.Dependencies);
         WriteObjects(bin.Objects);
+
+        return this._writer.ToString();
     }
 
     private void WriteHeader() => this._writer.WriteLine("#PROP_text");


### PR DESCRIPTION
- this makes more sense imo, allows reusing the class for multiple PropertyBin writes and fixes CurrentCulture use (StreamWriter ALWAYS uses `CurrentCulture` and needs to be subclasses to be able to change it :)))))))))))