### PR TITLE
Fix block count calculation for rgba8 TEX

### DIFF
--- a/src/LeagueToolkit/Core/Renderer/Texture.cs
+++ b/src/LeagueToolkit/Core/Renderer/Texture.cs
@@ -96,7 +96,7 @@ namespace LeagueToolkit.Core.Renderer
                 // Calculate dimensions of current mipmap
                 int currentWidth = Math.Max(width >> i, 1);
                 int currentHeight = Math.Max(height >> i, 1);
-                decoder.GetBlockCount(currentWidth, currentHeight, out int widthInBlocks, out int heightInBlocks);
+                CalculateBlockCount(format, currentWidth, currentHeight, out int widthInBlocks, out int heightInBlocks);
 
                 int mipMapSize = widthInBlocks * heightInBlocks * blockSize;
                 using MemoryOwner<byte> mipMapBufferOwner = MemoryOwner<byte>.Allocate(mipMapSize);
@@ -183,6 +183,19 @@ namespace LeagueToolkit.Core.Renderer
             stream.Position -= 4;
 
             return magic == 0x00584554; // "TEX\0"
+        }
+
+        private static void CalculateBlockCount(
+            ExtendedTextureFormat format,
+            int pixelWidth,
+            int pixelHeight,
+            out int blocksWidth,
+            out int blocksHeight
+            )
+        {
+            int blockLength = format == ExtendedTextureFormat.RGBA8 ? 1 : 4;
+            blocksWidth = (pixelWidth + blockLength - 1) / blockLength;
+            blocksHeight = (pixelHeight + blockLength - 1) / blockLength;
         }
     }
 

--- a/src/LeagueToolkit/Core/Renderer/Texture.cs
+++ b/src/LeagueToolkit/Core/Renderer/Texture.cs
@@ -96,7 +96,7 @@ namespace LeagueToolkit.Core.Renderer
                 // Calculate dimensions of current mipmap
                 int currentWidth = Math.Max(width >> i, 1);
                 int currentHeight = Math.Max(height >> i, 1);
-                CalculateBlockCount(format, currentWidth, currentHeight, out int widthInBlocks, out int heightInBlocks);
+                (int widthInBlocks, int heightInBlocks) = CalculateBlockCount(format, currentWidth, currentHeight);
 
                 int mipMapSize = widthInBlocks * heightInBlocks * blockSize;
                 using MemoryOwner<byte> mipMapBufferOwner = MemoryOwner<byte>.Allocate(mipMapSize);
@@ -185,17 +185,17 @@ namespace LeagueToolkit.Core.Renderer
             return magic == 0x00584554; // "TEX\0"
         }
 
-        private static void CalculateBlockCount(
+        private static (int blockWidth, int blockHeight) CalculateBlockCount(
             ExtendedTextureFormat format,
             int pixelWidth,
-            int pixelHeight,
-            out int blocksWidth,
-            out int blocksHeight
+            int pixelHeight
             )
         {
             int blockLength = format == ExtendedTextureFormat.RGBA8 ? 1 : 4;
-            blocksWidth = (pixelWidth + blockLength - 1) / blockLength;
-            blocksHeight = (pixelHeight + blockLength - 1) / blockLength;
+            int blockWidth = (pixelWidth + blockLength - 1) / blockLength;
+            int blockHeight = (pixelHeight + blockLength - 1) / blockLength;
+
+            return (blockWidth, blockHeight);
         }
     }
 

--- a/src/LeagueToolkit/Core/Renderer/Texture.cs
+++ b/src/LeagueToolkit/Core/Renderer/Texture.cs
@@ -185,17 +185,17 @@ namespace LeagueToolkit.Core.Renderer
             return magic == 0x00584554; // "TEX\0"
         }
 
-        private static (int blockWidth, int blockHeight) CalculateBlockCount(
+        private static (int widthInBlocks, int heightInBlocks) CalculateBlockCount(
             ExtendedTextureFormat format,
             int pixelWidth,
             int pixelHeight
-            )
+        )
         {
             int blockLength = format == ExtendedTextureFormat.RGBA8 ? 1 : 4;
-            int blockWidth = (pixelWidth + blockLength - 1) / blockLength;
-            int blockHeight = (pixelHeight + blockLength - 1) / blockLength;
+            int widthInBlocks = (pixelWidth + blockLength - 1) / blockLength;
+            int heightInBlocks = (pixelHeight + blockLength - 1) / blockLength;
 
-            return (blockWidth, blockHeight);
+            return (widthInBlocks, heightInBlocks);
         }
     }
 


### PR DESCRIPTION
This (fixes) https://github.com/Crauzer/Obsidian/issues/195.
The underlying issue is that `BcDecoder.GetBlockCount` assumed a fixed 4x4 size per block, which may be valid for all DXTn formats but doesn't hold true for RGBA8, which has 1x1 "blocks". So, I've created a custom function that does the calculation with RGBA8 in mind.

Note that I haven't checked whether ETC1/ETC2 are correct now, but it can't be worse than before.