### PR TITLE
Add Benchmark project; optimize code based on benchmark

### DIFF
--- a/src/LeagueToolkit.Benchmarks/LeagueToolkit.Benchmarks.csproj
+++ b/src/LeagueToolkit.Benchmarks/LeagueToolkit.Benchmarks.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <Import Project="../Common.props" />
+    
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\LeagueToolkit\LeagueToolkit.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/LeagueToolkit.Benchmarks/Program.cs
+++ b/src/LeagueToolkit.Benchmarks/Program.cs
@@ -1,0 +1,4 @@
+﻿using BenchmarkDotNet.Running;
+using LeagueToolkit.Benchmarks;
+
+BenchmarkRunner.Run<ReleaseManifestBenchmarks>();

--- a/src/LeagueToolkit.Benchmarks/ReleaseManifestBenchmarks.cs
+++ b/src/LeagueToolkit.Benchmarks/ReleaseManifestBenchmarks.cs
@@ -1,0 +1,50 @@
+using BenchmarkDotNet.Attributes;
+using LeagueToolkit.IO.ReleaseManifestFile;
+
+namespace LeagueToolkit.Benchmarks;
+
+[MemoryDiagnoser]
+public class ReleaseManifestBenchmarks
+{
+    private static readonly string[] ManifestUrls =
+    {
+        "https://lol.secure.dyn.riotcdn.net/channels/public/releases/3379CAB8EBF11345.manifest",
+        "https://lol.secure.dyn.riotcdn.net/channels/public/releases/6ADDAB3D6812B9A9.manifest",
+        "https://bacon.secure.dyn.riotcdn.net/channels/public/releases/BA2874BED61C60E1.manifest",
+        "https://bacon.secure.dyn.riotcdn.net/channels/public/releases/CB37BF993B8F1F7C.manifest",
+        "https://ks-foundation.secure.dyn.riotcdn.net/channels/public/releases/E14FCA78EA784741.manifest",
+        "https://valorant.secure.dyn.riotcdn.net/channels/public/releases/B1158BEBA8E7626F.manifest"
+    };
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        using var httpClient = new HttpClient();
+        foreach (string path in ManifestUrls)
+        {
+            using Task<Stream> response = httpClient.GetStreamAsync(path);
+            string fileName = Path.GetFileName(path);
+            using FileStream fs = File.Create(fileName);
+            response.Result.CopyTo(fs);
+        }
+    }
+
+    [Benchmark]
+    public void LoadManifests()
+    {
+        foreach (string path in ManifestUrls)
+        {
+            var _ = new ReleaseManifest(Path.GetFileName(path));
+        }
+    }
+
+    [Benchmark]
+    public void LoadAndWriteManifests()
+    {
+        foreach (string path in ManifestUrls)
+        {
+            var manifest = new ReleaseManifest(Path.GetFileName(path));
+            manifest.Write("temp");
+        }
+    }
+}

--- a/src/LeagueToolkit.sln
+++ b/src/LeagueToolkit.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LeagueToolkit.Meta.Dump", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "_build", "build\_build.csproj", "{DE52499D-FD8B-41A5-89C3-C2714948C9F5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LeagueToolkit.Benchmarks", "LeagueToolkit.Benchmarks\LeagueToolkit.Benchmarks.csproj", "{05740646-1F39-4BB8-B640-9754CA9E5836}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -49,6 +51,10 @@ Global
 		{F658EBCF-091E-42B8-A2D2-6038239E8A04}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F658EBCF-091E-42B8-A2D2-6038239E8A04}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F658EBCF-091E-42B8-A2D2-6038239E8A04}.Release|Any CPU.Build.0 = Release|Any CPU
+		{05740646-1F39-4BB8-B640-9754CA9E5836}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{05740646-1F39-4BB8-B640-9754CA9E5836}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{05740646-1F39-4BB8-B640-9754CA9E5836}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{05740646-1F39-4BB8-B640-9754CA9E5836}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Adds a simple benchmark project that can be used to benchmark certain code paths.

I've already applied one commit that optimizes memory usage in ReleaseManifest parsing. It's probably possible to further optimize by using `ArrayPool.Shared` instead of `new`, but I didn't want to overengineer for now.